### PR TITLE
Added minor note in Participation/Advanced Lvl 2

### DIFF
--- a/testnet/node-running/advanced-lvl.2.md
+++ b/testnet/node-running/advanced-lvl.2.md
@@ -42,6 +42,8 @@ algocfg set -p DNSBootstrapID -v "<network>.voi.network"
 algocfg set -p GossipFanout -v 9
 ```
 
+_Note: You can use these commands as provided, no need to replace `<network>`._
+
 Your `/var/lib/algorand/config.json` should look like :
 
 ```json


### PR DESCRIPTION
Added note to prevent a similar difficulty - the `<network>` value seems like a placeholder we are meant to replace. It is not.